### PR TITLE
Update LineGraph.java

### DIFF
--- a/HoloGraphLibrary/src/com/echo/holographlibrary/LineGraph.java
+++ b/HoloGraphLibrary/src/com/echo/holographlibrary/LineGraph.java
@@ -194,7 +194,7 @@ public class LineGraph extends View {
                 sidePadding = txtPaint.measureText(max);
 			
 			float usableHeight = getHeight() - bottomPadding - topPadding;
-			float usableWidth = getWidth() - sidePadding;
+			float usableWidth = getWidth() - sidePadding*2;
 			float lineSpace = usableHeight/10;
 			
 			int lineCount = 0;


### PR DESCRIPTION
Multiply sidePadding for usableWidth with 2 (left+right) 

-> Otherwise a Point at the max value on X-axis is out of Fragment:

Issue:
http://www.abload.de/image.php?img=holographlibrary_linekdk1h.png

Fix:
http://abload.de/img/holographlibrary_linef7kq4.png

PS.: I just tried it with my Fragments using the HoloEverywhere library
