### PR TITLE
[fix] fix type of BarStackSegment.Value.

### DIFF
--- a/HoloGraphLibrary/src/com/echo/holographlibrary/BarGraph.java
+++ b/HoloGraphLibrary/src/com/echo/holographlibrary/BarGraph.java
@@ -139,7 +139,7 @@ public class BarGraph extends View {
 
                 if(p.getStackedBar()){
                     ArrayList<BarStackSegment> values = new ArrayList<BarStackSegment>(p.getStackedValues());
-                    int prevValue = 0;
+                    float prevValue = 0;
                     for(BarStackSegment value : values) {
                         value.Value += prevValue;
                         prevValue += value.Value;

--- a/HoloGraphLibrary/src/com/echo/holographlibrary/BarStackSegment.java
+++ b/HoloGraphLibrary/src/com/echo/holographlibrary/BarStackSegment.java
@@ -4,7 +4,7 @@ package com.echo.holographlibrary;
  * Created by Aaron on 19/10/2014.
  */
 public class BarStackSegment {
-    public int Value;
+    public float Value;
     public int Color;
     public BarStackSegment(int val, int color){
         Value = val;


### PR DESCRIPTION
type of BarStackSegment.Value should be float, because we should tailor to the Bar.Value type.